### PR TITLE
Add Keep Alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This program relies on 2 external libraries: Qt 6 and libbzip2.  Bsdiff is also 
 
 ##### Ubuntu / Debian
 
-Required dependency packages: `qmake6 qt6-webengine-dev build-essential libbz2-dev`.
+Required dependency packages: `qmake6 qt6-webengine-dev build-essential libbz2-dev libxdo-dev`.
 
 To build and install:
 ```
@@ -64,7 +64,7 @@ sudo make install
 
 ##### OpenSuse
 
-Required dependency packages: `libbz2-devel qt6-webengine-devel`
+Required dependency packages: `libbz2-devel qt6-webengine-devel xdotool-devel`
 
 To build and install:
 ```
@@ -75,7 +75,7 @@ sudo make install
 
 ##### Fedora
 
-Required dependency packages: `qt6-qtbase-devel qt6-qtwebengine-devel gcc-c++ bzip2-devel`.
+Required dependency packages: `qt6-qtbase-devel qt6-qtwebengine-devel gcc-c++ bzip2-devel xdotool-devel`.
 
 To build and install:
 ```
@@ -86,7 +86,7 @@ sudo make install
 
 ##### Arch
 
-Required dependency packages: `bzip2 qt6-base qt6-webengine`.
+Required dependency packages: `bzip2 qt6-base qt6-webengine xdotool`.
 
 AUR package for the latest git version: https://aur.archlinux.org/packages/shticker-book-rewritten-git/.
 

--- a/Schticker-Book-Rewritten.pro
+++ b/Schticker-Book-Rewritten.pro
@@ -83,6 +83,7 @@ unix:!mac {
         icon64 \
         icon128 \
         icon256
+    LIBS += -lxdo
     desktop.path = $$DATADIR/applications
     desktop.files += shticker-book-rewritten.desktop
     icon32.path = $$DATADIR/icons/hicolor/32x32/apps

--- a/Schticker-Book-Rewritten.pro
+++ b/Schticker-Book-Rewritten.pro
@@ -69,6 +69,7 @@ RESOURCES += \
 LIBS += -lbz2
 
 DISTFILES += LICENSE
+
 unix:!mac {
     isEmpty(PREFIX):PREFIX = /usr
     BINDIR = $$PREFIX/bin
@@ -94,6 +95,10 @@ unix:!mac {
     icon128.files += resources/128x128/shticker-book-rewritten.png
     icon256.path = $$DATADIR/icons/hicolor/256x256/apps
     icon256.files += resources/256x256/shticker-book-rewritten.png
+}
+
+win32 {
+    LIBS += -luser32
 }
 
 RC_FILE = windows/shticker-book-rewritten.rc

--- a/globaldefines.h
+++ b/globaldefines.h
@@ -24,7 +24,7 @@
 #endif // GLOBALDEFINES_H
 
 //Platform Specific Configurations
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX)
 #define DEFAULT_PATH QDir::homePath() + QString("/.ttr")
 #define PLATFORM    "linux2"
 #define ENGINE_FILENAME QString("./TTREngine")

--- a/launcherwindow.h
+++ b/launcherwindow.h
@@ -28,6 +28,22 @@
 #include <QMainWindow>
 #include <QList>
 
+#ifdef __linux__
+#include <xdo.h>
+#undef Bool
+#undef CursorShape
+#undef Expose
+#undef KeyPress
+#undef KeyRelease
+#undef FocusIn
+#undef FocusOut
+#undef FontChange
+#undef None
+#undef Status
+#undef Unsorted
+#undef Type
+#endif
+
 namespace Ui {
 class LauncherWindow;
 }
@@ -47,8 +63,8 @@ private slots:
     void relayHideProgressBar();
     void loginReady();
     void initiateLogin();
-    void gameHasStarted();
-    void gameHasFinished(int, QByteArray);
+    void gameHasStarted(qint64);
+    void gameHasFinished(int, qint64, QByteArray);
     void authenticationFailed();
     void newsViewLoaded();
     void fillCredentials(int);
@@ -56,6 +72,8 @@ private slots:
     void updateFiles();
     void updatesReady();
     void toggleAutoUpdates();
+    void toggleKeepAlive();
+    void runKeepAlive();
 
 signals:
     void sendMessage(QString);
@@ -69,13 +87,20 @@ private:
     Ui::LauncherWindow *ui;
     bool loginIsReady;
     LoginWorker *loginWorker;
-    int gameInstances;
+    QList<qint64> gameInstances;
     QThread *updateThread;
     QList<LauncherUser> savedUsers;
     QString filePath;
     QString cachePath;
     bool autoUpdate;
+    bool keepAlive;
+    QTimer *keepAliveTimer = nullptr;
 
+#ifdef __linux__
+    xdo_t *xdo = nullptr;
+#endif
+
+    void updateKeepAliveTimer();
     void readSettings();
     void readSettingsPath();
     void writeSettings();

--- a/launcherwindow.h
+++ b/launcherwindow.h
@@ -28,7 +28,7 @@
 #include <QMainWindow>
 #include <QList>
 
-#ifdef __linux__
+#if defined(Q_OS_LINUX)
 #include <xdo.h>
 #undef Bool
 #undef CursorShape
@@ -42,6 +42,8 @@
 #undef Status
 #undef Unsorted
 #undef Type
+#elif defined(Q_OS_WIN)
+#include <windows.h>
 #endif
 
 namespace Ui {
@@ -96,7 +98,10 @@ private:
     bool keepAlive;
     QTimer *keepAliveTimer = nullptr;
 
-#ifdef __linux__
+#if defined(Q_OS_WIN)
+    unsigned int windowsKeptAlive;
+    static BOOL CALLBACK keepAliveWindowReceived(HWND hwnd, LPARAM lParam);
+#elif defined(Q_OS_LINUX)
     xdo_t *xdo = nullptr;
 #endif
 

--- a/launcherwindow.ui
+++ b/launcherwindow.ui
@@ -106,105 +106,6 @@
             <property name="horizontalSpacing">
              <number>6</number>
             </property>
-            <item row="6" column="1">
-             <widget class="QComboBox" name="savedToonsBox">
-              <property name="currentText">
-               <string/>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="1">
-             <widget class="QProgressBar" name="progressBar">
-              <property name="value">
-               <number>0</number>
-              </property>
-              <property name="textVisible">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="1">
-             <widget class="QLabel" name="statusLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>300</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Checking for updates.</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-              <property name="buddy">
-               <cstring>launcherView</cstring>
-              </property>
-             </widget>
-            </item>
-            <item row="11" column="1">
-             <widget class="QPushButton" name="goButton">
-              <property name="text">
-               <string>Launch!</string>
-              </property>
-             </widget>
-            </item>
-            <item row="10" column="1">
-             <widget class="QCheckBox" name="saveCredentialsBox">
-              <property name="text">
-               <string>Save username and password</string>
-              </property>
-             </widget>
-            </item>
-            <item row="7" column="1">
-             <widget class="QLineEdit" name="usernameBox">
-              <property name="placeholderText">
-               <string>Username</string>
-              </property>
-              <property name="clearButtonEnabled">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="8" column="1">
-             <widget class="QLineEdit" name="passwordBox">
-              <property name="echoMode">
-               <enum>QLineEdit::Password</enum>
-              </property>
-              <property name="placeholderText">
-               <string>Password</string>
-              </property>
-              <property name="clearButtonEnabled">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="9" column="1">
-             <widget class="QLineEdit" name="twofactorBox">
-              <property name="echoMode">
-               <enum>QLineEdit::Password</enum>
-              </property>
-              <property name="placeholderText">
-               <string>Two Factor Secret (Optional)</string>
-              </property>
-              <property name="clearButtonEnabled">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="12" column="1">
-             <widget class="QPushButton" name="updateButton">
-              <property name="text">
-               <string>Update Game Files</string>
-              </property>
-             </widget>
-            </item>
             <item row="1" column="1">
              <spacer name="verticalSpacer">
               <property name="orientation">
@@ -237,6 +138,105 @@
               </property>
               <property name="styleSheet">
                <string notr="true">background-image:url(:/resources/TTR_Logo.png);background-repeat:no-repeat;</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLabel" name="statusLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>300</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Checking for updates.</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+              <property name="buddy">
+               <cstring>launcherView</cstring>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QProgressBar" name="progressBar">
+              <property name="value">
+               <number>0</number>
+              </property>
+              <property name="textVisible">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QComboBox" name="savedToonsBox">
+              <property name="currentText">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="QLineEdit" name="usernameBox">
+              <property name="placeholderText">
+               <string>Username</string>
+              </property>
+              <property name="clearButtonEnabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="1">
+             <widget class="QLineEdit" name="passwordBox">
+              <property name="echoMode">
+               <enum>QLineEdit::Password</enum>
+              </property>
+              <property name="placeholderText">
+               <string>Password</string>
+              </property>
+              <property name="clearButtonEnabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="8" column="1">
+             <widget class="QLineEdit" name="twofactorBox">
+              <property name="echoMode">
+               <enum>QLineEdit::Password</enum>
+              </property>
+              <property name="placeholderText">
+               <string>Two Factor Secret (Optional)</string>
+              </property>
+              <property name="clearButtonEnabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="9" column="1">
+             <widget class="QCheckBox" name="saveCredentialsBox">
+              <property name="text">
+               <string>Save username and password</string>
+              </property>
+             </widget>
+            </item>
+            <item row="10" column="1">
+             <widget class="QPushButton" name="goButton">
+              <property name="text">
+               <string>Launch!</string>
+              </property>
+             </widget>
+            </item>
+            <item row="11" column="1">
+             <widget class="QPushButton" name="updateButton">
+              <property name="text">
+               <string>Update Game Files</string>
               </property>
              </widget>
             </item>
@@ -405,6 +405,13 @@
          <widget class="QCheckBox" name="updatesCheckBox">
           <property name="text">
            <string>Enable Automatic Game File Updates</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="keepAliveCheckBox">
+          <property name="text">
+           <string>Keep Toons Alive</string>
           </property>
          </widget>
         </item>

--- a/loginworker.cpp
+++ b/loginworker.cpp
@@ -256,7 +256,7 @@ void LoginWorker::startGame(QString cookie, QString gameServer)
     gameEnvironment.insert("TTR_PLAYCOOKIE", cookie);
     gameEnvironment.insert("TTR_GAMESERVER", gameServer);
 
-#ifdef Q_OS_MAC
+#if defined(Q_OS_MAC)
     gameEnvironment.insert("DYLD_LIBRARY_PATH", LIBRARY_PATH);
 #endif
 

--- a/loginworker.cpp
+++ b/loginworker.cpp
@@ -207,6 +207,7 @@ void LoginWorker::startTwoFactorAuthentication()
         jsonDocument = QJsonDocument::fromJson(replyData, parseError);   //parse the downloaded file into a JSON array
         jsonObject = jsonDocument.object();
     }
+
     if(jsonObject["success"].toString() != "false")
     {
         qDebug() << "Two Factor authentication complete";
@@ -271,10 +272,10 @@ void LoginWorker::startGame(QString cookie, QString gameServer)
 
 void LoginWorker::gameHasStarted()
 {
-    emit gameStarted();
+    emit gameStarted(gameProcess->processId());
 }
 
 void LoginWorker::gameHasFinished(int exitCode)
 {
-    emit gameFinished(exitCode, gameProcess->readAllStandardError());
+    emit gameFinished(exitCode, gameProcess->processId(), gameProcess->readAllStandardError());
 }

--- a/loginworker.h
+++ b/loginworker.h
@@ -40,8 +40,8 @@ public:
 
 signals:
     void sendMessage(QString);
-    void gameStarted();
-    void gameFinished(int, QByteArray);
+    void gameStarted(qint64);
+    void gameFinished(int, qint64, QByteArray);
     void authenticationFailed();
 
 public slots:

--- a/patchworker.cpp
+++ b/patchworker.cpp
@@ -55,7 +55,7 @@
 #include <fcntl.h>
 #include <QDebug>
 
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32)
 #include "windows/fake_unistd.h"
 #define fseeko fseek
 #else

--- a/patchworker.h
+++ b/patchworker.h
@@ -27,7 +27,7 @@
 //need to include winsock.h to define u_char for Windows
 //O_BINARY must be added to the open() functions for Windows but not for Linux
 #include <QtGlobal>
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN)
 #include <winsock.h>
 #define OPEN_ARGS O_RDONLY|O_BINARY
 #define WRITE_ARGS O_CREAT|O_TRUNC|O_WRONLY|O_BINARY
@@ -37,7 +37,7 @@
 #endif
 //*********************************************************
 
-#ifdef Q_OS_MAC
+#if defined(Q_OS_MAC)
 #include <sys/types.h>
 #endif
 

--- a/updateworker.cpp
+++ b/updateworker.cpp
@@ -216,7 +216,7 @@ void UpdateWorker::patchManifestReady(QJsonDocument patchManifest)
     emit updateComplete();
 
     //on Linux platforms we need to check if TTREngine is executable since it isn't by default
-    #ifdef Q_OS_LINUX
+    #if defined(Q_OS_LINUX)
         #include <QFileInfo>
 
         QFileInfo engine(QString(filePath + "TTREngine"));


### PR DESCRIPTION
This pull request adds Keep Alive to the Shticker Book Rewritten settings. By default, it is disabled.

On Windows, this is implemented using the EnumWindows/PostMessage API. All windows are enumerated until we find all of our game instances, and the End key is sent to the window every minute.

On Linux, this is implemented using the libxdo library. With libxdo, the program searches for windows with the Toontown Rewritten title, and sends keystrokes to those. "xdotool" has to be added to the PKGBUILD in this case.

On Mac, this is implemented by calling AppleScript (osascript), telling it to send End to all windows with the title "Toontown Rewritten".